### PR TITLE
fix: Navigating to multiple units error in legacy UI

### DIFF
--- a/h5pxblock/static/js/src/h5pxblock.js
+++ b/h5pxblock/static/js/src/h5pxblock.js
@@ -8,7 +8,7 @@ function H5PPlayerXBlock(runtime, element, args) {
     const contentxResultSaveUrl = runtime.handlerUrl(element, 'result_handler');
 
     const playerPromise = function edXH5PPlayer(el) {        
-        if (el) {
+        if (el && $(el).children('.h5p-iframe-wrapper').length == 0) {
             const userObj = { 'name': args.user_full_name, 'mail': args.user_email };
             const options = {
                 h5pJsonPath: args.h5pJsonPath,
@@ -27,7 +27,6 @@ function H5PPlayerXBlock(runtime, element, args) {
                 ajax: { 
                     contentUserDataUrl: contentUserDataUrl
                 }
-
             }
             return new H5PStandalone.H5P(el, options).then(function(){ 
                 $(el).siblings('.spinner-container').find('.spinner-border').hide();

--- a/h5pxblock/utils.py
+++ b/h5pxblock/utils.py
@@ -44,7 +44,7 @@ def delete_existing_files_cloud(storage, path):
     dir_names, file_names = storage.listdir(path)
     with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
         for file_name in file_names:
-            file_path = os.path.join(path, file_name)            
+            file_path = os.path.join(path, file_name)
             future = executor.submit(storage.delete, file_path)
             future.add_done_callback(future_result_handler)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def package_data(pkg, roots):
 
 setup(
     name='h5p-xblock',
-    version='0.2.1',
+    version='0.2.2',
     description='XBlock to play self hosted h5p content inside open edX',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
PR has changes to fix this error when we navigate from one unit to another having h5p content
```
TypeError: Cannot set properties of null (setting 'jQuery')
```