### PR TITLE
feat: allow specifying an alternative storage through django settings

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -6,7 +6,6 @@ import logging
 import pkg_resources
 
 from django.conf import settings
-from django.core.files.storage import default_storage
 from django.template import Context, Template
 from django.utils import timezone
 from webob import Response
@@ -15,7 +14,7 @@ from xblock.completable import CompletableXBlockMixin
 from xblock.core import XBlock
 from xblock.fields import Scope, String, Boolean, Integer, Dict, DateTime, UNIQUE_ID
 from xblock.fragment import Fragment
-from h5pxblock.utils import str2bool, unpack_and_upload_on_cloud, unpack_package_local_path
+from h5pxblock.utils import get_h5p_storage, str2bool, unpack_and_upload_on_cloud, unpack_package_local_path
 
 
 # Make '_' a no-op so we can scrape strings
@@ -26,6 +25,7 @@ log = logging.getLogger(__name__)
 H5P_ROOT = os.path.join(settings.MEDIA_ROOT, "h5pxblockmedia")
 H5P_URL = os.path.join(settings.MEDIA_URL, "h5pxblockmedia")
 
+H5P_STORAGE = get_h5p_storage()
 
 @XBlock.wants('user')
 @XBlock.wants('i18n')
@@ -122,7 +122,7 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
 
     @property
     def store_content_on_local_fs(self):
-        return default_storage.__class__.__name__ == 'FileSystemStorage'
+        return H5P_STORAGE.__class__.__name__ == 'FileSystemStorage'
 
     @property
     def get_block_path_prefix(self):
@@ -256,9 +256,9 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
                 self.h5p_content_json_path = self.h5p_content_url
             else:
                 unpack_and_upload_on_cloud(
-                    h5p_package, default_storage, self.cloud_storage_path
+                    h5p_package, H5P_STORAGE, self.cloud_storage_path
                 )
-                self.h5p_content_json_path = default_storage.url(self.cloud_storage_path)
+                self.h5p_content_json_path = H5P_STORAGE.url(self.cloud_storage_path)
         elif request.params["h5_content_path"]:
             self.h5p_content_json_path = request.params["h5_content_path"]
 

--- a/h5pxblock/utils.py
+++ b/h5pxblock/utils.py
@@ -9,11 +9,34 @@ import shutil
 from zipfile import is_zipfile, ZipFile
 from django.conf import settings
 from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage, get_storage_class
 
 log = logging.getLogger(__name__)
 
 
 MAX_WORKERS = getattr(settings, "THREADPOOLEXECUTOR_MAX_WORKERS", 10)
+
+
+def get_h5p_storage():
+    """
+    Returns storage for h5p content
+
+    If H5PXBLOCK_STORAGE is defined in django settings, intializes storage using the
+    specified settings. Otherwise, returns default_storage.
+    """
+    h5p_storage_settings = getattr(settings, "H5PXBLOCK_STORAGE", None)
+
+    if not h5p_storage_settings:
+        return default_storage
+
+    storage_class_import_path = h5p_storage_settings.get("storage_class", None)
+    storage_settings = h5p_storage_settings.get("settings", {})
+
+    storage_class = get_storage_class(storage_class_import_path)
+
+    storage = storage_class(**storage_settings)
+
+    return storage
 
 
 def str2bool(val):


### PR DESCRIPTION
## Description

This PR adds a way to specify via Django settings storage for storing content different to the `default_storage`.

By default the XBlock will still use the `default_storage`. However, now an alternative storage can be specified via `H5PXLBOCK_STORAGE` settings, which allows to specify `storage_class` and a dictionary of settings. If `storage_class` is not specified, the implementation relies on `get_storage_class` from `django.core.files.storage` to get the default storage class. If settings are not specified, whatever mechanism there is for initializing the default settings will work, e.g. for `S3Boto3Storage` would pull them from `django.conf.settings` - [ref](https://github.com/jschneier/django-storages/blob/1.8/storages/backends/s3boto3.py#L185-L223). What keys to pass to the storage class can be figured out by reading it's source code. For example, for `S3Boto3Storage`, looking at [these line of code](https://github.com/jschneier/django-storages/blob/1.8/storages/backends/s3boto3.py#L185-L223) in it's constructor, we can tell that to overwrite a settings, we should find it's name [here](https://github.com/jschneier/django-storages/blob/1.8/storages/backends/s3boto3.py#L185-L223), e.g. `bucket_name`, `querystring_auth`, `access_key`, `secret_key`, e.t.c., would be used as keys in the `settings` dictionary.

Our need for this change comes from the fact that we want to keep the default storage, which is an S3 bucket, private. Presigning urls doesn't work in this case, because of how `h5pxblock` and `h5p-standalone` work. So instead of using the default storage, what we want to be able to do, is to have a separate public bucket, and pass it to the `h5pxblock` to use instead of the default one. We also want to be able to pass overwrites for certain settings.

### Examples
For the use case described above 

* Via DJango settings:
  ```python
  H5PXBLOCK_STORAGE = {
      'storage_class': 'storages.backends.s3boto3.S3Boto3Storage',
      'settings': {
          'bucket_name': 'non-default-bucket-name',
          'querystring_auth': false,
      },
  }
  ```
* Via `{lms,cms}.yml` (on `tutor` can use `YAML_LMS_ENV` and `YAML_CMS_ENV`):
  ```yaml
  H5XBLOCK_STORAGE:
    storage_class: 'storages.backends.s3boto3.S3Boto3Storage'
    settings:
      bucket_name: 'non-default-bucket-name'
      querystring_auth: false
  ```
  
## Supporting information

[OpenCraft private JIRA Ticket - BB-7138](https://tasks.opencraft.com/browse/BB-7138)

## Testing instructions

1. Setup `master` or `nutmeg.master` devstack.
1. Clone `h5pxblock` to `<devstack parent>/src`.
1. `make dev.up.lms+studio+frontend-app-learning+frontend-app-course-authoring`.
1. Devstack by default uses local storage to store content, but via this feature we can pass an S3 bucket to the `h5pxblock`. Create a public S3 bucket and make sure to add the following to bucket's `Permissions -> CORS` (without that devstack LMS will have CORS issues loading content from the bucket):
    ```json
    [
        {
            "AllowedHeaders": [
                "*"
            ],
            "AllowedMethods": [
                "GET",
                "PUT",
                "POST",
                "HEAD",
                "DELETE"
            ],
            "AllowedOrigins": [
                "*"
            ],
            "ExposeHeaders": [],
            "MaxAgeSeconds": 3000
        }
    ]
    ```
1. Add the necessary settings to `<devstack parent>/edx-platform/{lms,cms}/envs/private.py`. Your settings in `private.py` should look something like this:
    ```python
    H5PXBLOCK_STORAGE = {
        'storage_class': 'storages.backends.s3boto3.S3Boto3Storage',
        'settings': {
            'access_key': '<aws-access-key-id>',
            'secret_key': '<aws-secret-access-key>',
            'bucket_name': 'non-default-bucket-name',
            'querystring_auth': False,
            # on devstack it has a default value which has to be changed; we can set it to None or an empty string
            'custom_domain': None  # or ''
        },
    }
    ```
1. `make {lms,studio}-shell` and inside both of the run `pip install -e /edx/src/h5pxblock`. `make {lms,studio}-restart` to restart both.
1. Create new course or use the demo one on the devstack.
1. Add `h5pxblock` in the advanced settings of the course in studio.
1. Add a new unit and `h5pxblock` in it, upload some `h5p` content by editing the `XBlock`. (Example content can be take from [here](https://h5p.org/content-types-and-applications)).
1. Verify that:
    1. Content got uploaded to the bucket you've specified.
    3. That when visiting the course in the LMS, the content is correctly loaded from the bucket.