### PR TITLE
fix: handle `TypeError` when assigning grade for first time with save_freq enabled

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -280,17 +280,21 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         except BaseException as exp:
             log.error("Error while marking completion %s", exp)
 
-        try:
-            if self.has_score and data['result'] and data['result']['score']:
-                grade_dict = {
-                    'value': data['result']['score']['raw'],
-                    'max_value': data['result']['score']['max'],
-                    'only_if_higher': True,
-                }
+        if self.has_score and data['result'] and data['result']['score']:
+            grade_dict = {
+                'value': data['result']['score']['raw'],
+                'max_value': data['result']['score']['max'],
+                'only_if_higher': True,
+            }
+            try:
                 self.runtime.publish(self, 'grade', grade_dict)
                 save_score = True
-        except BaseException as exp:
-            log.error("Error while publishing score %s", exp)
+            except TypeError:
+                grade_dict["only_if_higher"] = False
+                self.runtime.publish(self, 'grade', grade_dict)
+                save_score = True
+            except BaseException as exp:
+                log.error("Error while publishing score %s", exp)
 
         return Response(
             json.dumps({"result": {"save_completion": save_completion, "save_score": save_score}}),


### PR DESCRIPTION
### Description
This PR fixes the error when grading using an H5P component with the `User content state save frequency` enabled.

### To Reproduce Error
1. Adds to a unit a H5P component.
2. Configure the H5P component: Adds a H5P content, e.g. [Interactive Video](https://h5p.org/interactive-video), set `Is Scorable = True`, and `User content state save frequency = 1` (or higher)
3. Configure the subsection of the unit as grading.
4. Solve some questions of the aggregated component from the LMS (not all of them need to be solved) and submit the answers.
5. In the logs of the container we can see this error:
    ```bash
    2023-08-22 22:10:22,680 ERROR 320 [h5pxblock.h5pxblock] [user 4] [ip 172.20.0.1] h5pxblock.py:293 - Error while 
    publishing score float() argument must be a string or a number, not 'NoneType'
    ```
This error happens because the first time the answers are uploaded, the [`previous_score`](https://github.com/openedx/edx-platform/blob/a4b11c02e0171b977abbd0c26ea7fae7be7ed36c/lms/djangoapps/grades/signals/handlers.py#L150) variable should be set to `None`, but for some reason, having the `User content state save frequency` field enabled does not happen. As the variable is not set to `None`, certain actions are executed ending in a `TyperError` in the [`compare_scores`](https://github.com/openedx/edx-platform/blob/a4b11c02e0171b977abbd0c26ea7fae7be7ed36c/openedx/core/lib/grade_utils.py#L19) method, since the parameters `earned1` and `possible1` are set to `None`.

### Before

https://github.com/edly-io/h5pxblock/assets/64033729/933f90a1-4680-42f3-a961-9648afbeb231

### After

https://github.com/edly-io/h5pxblock/assets/64033729/d766ad86-d539-4b76-bf58-c833562b2170

