### PR TITLE
feat: add status updates for interactions in the student view

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -144,14 +144,14 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         scope=Scope.user_state,
     )
 
-    score = Integer(
+    raw_score = Integer(
         display_name=_("Score"),
         help=_("The score of the assignment."),
         default=0,
         scope=Scope.user_state,
     )
 
-    max_score = Integer(
+    max_raw_score = Integer(
         display_name=_("Maximum score"),
         help=_("The maximum score of the assignment."),
         default=0,
@@ -400,8 +400,8 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
             except BaseException as exp:
                 log.error("Error while publishing score %s", exp)
             if save_score:
-                self.score = data['result']['score']['raw']
-                self.max_score = data['result']['score']['max']
+                self.raw_score = data['result']['score']['raw']
+                self.max_raw_score = data['result']['score']['max']
         self.submission_status = SubmissionStatus.COMPLETED.value
         return Response(
             json.dumps({"result": {"save_completion": save_completion, "save_score": save_score}}),

--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -376,6 +376,7 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         try:
             self.emit_completion(1.0)
             save_completion = True
+            self.submission_status = SubmissionStatus.COMPLETED.value
         except BaseException as exp:
             log.error("Error while marking completion %s", exp)
 
@@ -402,7 +403,6 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
             if save_score:
                 self.raw_score = data['result']['score']['raw']
                 self.max_raw_score = data['result']['score']['max']
-        self.submission_status = SubmissionStatus.COMPLETED.value
         return Response(
             json.dumps({"result": {"save_completion": save_completion, "save_score": save_score}}),
             content_type="application/json",

--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -137,24 +137,20 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         scope=Scope.settings,
     )
 
+    weighted_score = Float(
+        display_name=_("Problem weighted score"),
+        help=_(
+            "Defines the weighted score of this problem. If "
+            "the value is not set, the problem is worth one point."
+        ),
+        scope=Scope.user_state,
+        default=1.0,
+    )
+
     submission_status = String(
         display_name=_("Submission status"),
         help=_("The submission status of the assignment."),
         default=SubmissionStatus.NOT_ATTEMPTED.value,
-        scope=Scope.user_state,
-    )
-
-    raw_score = Integer(
-        display_name=_("Score"),
-        help=_("The score of the assignment."),
-        default=0,
-        scope=Scope.user_state,
-    )
-
-    max_raw_score = Integer(
-        display_name=_("Maximum score"),
-        help=_("The maximum score of the assignment."),
-        default=0,
         scope=Scope.user_state,
     )
 
@@ -183,7 +179,7 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
             context,
             i18n_service=self.runtime.service(self, 'i18n'),
         )
-    
+
     def max_score(self):
         return self.points
 
@@ -401,9 +397,9 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
             except BaseException as exp:
                 log.error("Error while publishing score %s", exp)
 
-            if save_score and data['result']['score']['raw'] > self.raw_score:
-                self.raw_score = data['result']['score']['raw']
-                self.max_raw_score = data['result']['score']['max']
+            if save_score and score > self.weighted_score:
+                self.weighted_score = score
+
         return Response(
             json.dumps({"result": {"save_completion": save_completion, "save_score": save_score}}),
             content_type="application/json",

--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -400,7 +400,8 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
                 save_score = True
             except BaseException as exp:
                 log.error("Error while publishing score %s", exp)
-            if save_score:
+
+            if save_score and data['result']['score']['raw'] > self.raw_score:
                 self.raw_score = data['result']['score']['raw']
                 self.max_raw_score = data['result']['score']['max']
         return Response(

--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -144,7 +144,7 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
             "the value is not set, the problem is worth one point."
         ),
         scope=Scope.user_state,
-        default=1.0,
+        default=0,
     )
 
     submission_status = String(

--- a/h5pxblock/static/html/h5pxblock.html
+++ b/h5pxblock/static/html/h5pxblock.html
@@ -4,6 +4,7 @@
 <div class="h5pxblock_block">
     {% if h5pblock.has_score %}
     <p> ({{ h5pblock.raw_score}}/{{ h5pblock.max_raw_score }} {% trans "points" %}) {% trans h5pblock.submission_status %}</p>
+    {% endif %}
     <div class="d-flex justify-content-center spinner-container">
         <div class="spinner-border" role="status">
             <span class="sr-only">{% trans "Loading..." %}</span>

--- a/h5pxblock/static/html/h5pxblock.html
+++ b/h5pxblock/static/html/h5pxblock.html
@@ -3,7 +3,9 @@
 {% if h5pblock.h5p_content_json_path %}
 <div class="h5pxblock_block">
     {% if h5pblock.has_score %}
-    <p> ({{ h5pblock.score}}/{{ h5pblock.max_score }}) {% trans "points" %} {% trans h5pblock.submission_status %}</p>
+    <p> ({{ h5pblock.score}}/{{ h5pblock.max_score }} {% trans "points" %}) {% trans h5pblock.submission_status %}</p>
+    {% else %}
+    <p> {% trans h5pblock.submission_status %}</p>
     {% endif %}
     <div class="d-flex justify-content-center spinner-container">
         <div class="spinner-border" role="status">

--- a/h5pxblock/static/html/h5pxblock.html
+++ b/h5pxblock/static/html/h5pxblock.html
@@ -2,6 +2,9 @@
 
 {% if h5pblock.h5p_content_json_path %}
 <div class="h5pxblock_block">
+    {% if h5pblock.has_score %}
+    <p> ({{ h5pblock.score}}/{{ h5pblock.max_score }}) {% trans "points" %} {% trans h5pblock.submission_status %}</p>
+    {% endif %}
     <div class="d-flex justify-content-center spinner-container">
         <div class="spinner-border" role="status">
             <span class="sr-only">{% trans "Loading..." %}</span>

--- a/h5pxblock/static/html/h5pxblock.html
+++ b/h5pxblock/static/html/h5pxblock.html
@@ -3,7 +3,7 @@
 {% if h5pblock.h5p_content_json_path %}
 <div class="h5pxblock_block">
     {% if h5pblock.has_score %}
-    <p> ({{ h5pblock.score}}/{{ h5pblock.max_score }} {% trans "points" %}) {% trans h5pblock.submission_status %}</p>
+    <p> ({{ h5pblock.raw_score}}/{{ h5pblock.max_raw_score }} {% trans "points" %}) {% trans h5pblock.submission_status %}</p>
     {% else %}
     <p> {% trans h5pblock.submission_status %}</p>
     {% endif %}

--- a/h5pxblock/static/html/h5pxblock.html
+++ b/h5pxblock/static/html/h5pxblock.html
@@ -4,9 +4,6 @@
 <div class="h5pxblock_block">
     {% if h5pblock.has_score %}
     <p> ({{ h5pblock.raw_score}}/{{ h5pblock.max_raw_score }} {% trans "points" %}) {% trans h5pblock.submission_status %}</p>
-    {% else %}
-    <p> {% trans h5pblock.submission_status %}</p>
-    {% endif %}
     <div class="d-flex justify-content-center spinner-container">
         <div class="spinner-border" role="status">
             <span class="sr-only">{% trans "Loading..." %}</span>

--- a/h5pxblock/static/html/h5pxblock.html
+++ b/h5pxblock/static/html/h5pxblock.html
@@ -3,7 +3,7 @@
 {% if h5pblock.h5p_content_json_path %}
 <div class="h5pxblock_block">
     {% if h5pblock.has_score %}
-    <p> ({{ h5pblock.raw_score}}/{{ h5pblock.max_raw_score }} {% trans "points" %}) {% trans h5pblock.submission_status %}</p>
+    <p> ({{ h5pblock.weighted_score}}/{{ h5pblock.points | floatformat:1 }} {% trans "points" %}) {% trans h5pblock.submission_status %}</p>
     {% endif %}
     <div class="d-flex justify-content-center spinner-container">
         <div class="spinner-border" role="status">


### PR DESCRIPTION
### Description
This PR adds new fields to inform students about their interaction status with the problem. Have they answered? What's their score? Since some H5P components do not explicitly show this.

We decided to use two states:
`Not attempted`: the default
`Completed`: when a student submits a problem, the status is updated to this one.

When the instructor cleans the student status, the state resets to `Not attempted`. Regarding the score, we're currently showing what the H5P content returns as raw score and max score. When the problem is not scored, then just the submission status is shown.

### How to test

1. Install this branch into your environment
2. Use H5P in your course as specified in the README file:
![image](https://github.com/edly-io/h5pxblock/assets/64440265/caa5f12a-9c14-4fc9-91d3-29d02f2c7f2b)
3. Download some H5P problems, like true/false questions.
4. Now, configure your content into your course. For this example I used the default values for the grading system.
5. As a student, go into your course and complete the problem. Now, you'll see a text showing the state of the submission:
![image](https://github.com/edly-io/h5pxblock/assets/64440265/52148f50-0d3c-4d31-ae99-cdcec01c9324)
Where the max score is the one configured in the Studio Edit view. When the problem is not scored, then nothing is shown.