### PR TITLE
fix: replace comma (`,`) by dot (`.`) in value of weight field

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -368,6 +368,8 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         if points < 0:
             raise JsonHandlerError(400, "Points must be a positive integer")
 
+        weight = weight.replace(",", ".")
+
         if weight:
             try:
                 weight = float(weight)


### PR DESCRIPTION
### Description
This PR fixes an error when editing an H5P component when the platform language is set to Spanish. In Spanish, the default value of the `weight` field is `(1,0)`, and when converting to `float` it breaks. 

### Screenshots

#### Before
![image](https://github.com/edly-io/h5pxblock/assets/64033729/d5a5273e-1df4-4b73-bbba-da7366481b87)

#### After
Error no longer occurs
![image](https://github.com/edly-io/h5pxblock/assets/64033729/7e0fbad0-9d49-4834-a36a-eadc1c3e3ca9)
