### PR TITLE
fix: CORS by reverting the h5p-standalone version

### DIFF
--- a/h5pxblock/static/js/src/h5pxblock.js
+++ b/h5pxblock/static/js/src/h5pxblock.js
@@ -16,9 +16,9 @@ function H5PPlayerXBlock(runtime, element, args) {
         const options = {
           h5pJsonPath: args.h5pJsonPath,
           frameJs:
-            "https://cdn.jsdelivr.net/npm/h5p-standalone@3.6.0/dist/frame.bundle.js",
+            "https://cdn.jsdelivr.net/npm/h5p-standalone@v3.5.1/dist/frame.bundle.js",
           frameCss:
-            "https://cdn.jsdelivr.net/npm/h5p-standalone@3.6.0/dist/styles/h5p.css",
+            "https://cdn.jsdelivr.net/npm/h5p-standalone@v3.5.1/dist/styles/h5p.css",
           frame: args.frame,
           copyright: args.copyright,
           icon: args.icon,
@@ -26,6 +26,9 @@ function H5PPlayerXBlock(runtime, element, args) {
           user: userObj,
           saveFreq: args.saveFreq,
           customJs: args.customJsPath,
+          // this option isn't enough because the fetch of library.json doesn't use this option
+          // view: https://github.com/tunapanda/h5p-standalone/pull/153
+          assetsRequestFetchOptions: {credentials: 'same-origin'},
           contentUserData: [
             {
               state: args.userData,
@@ -118,7 +121,7 @@ function loadJS(callback) {
   } else {
     // Load jsMind dynamically using $.getScript
     $.getScript(
-      "https://cdn.jsdelivr.net/npm/h5p-standalone@3.6.0/dist/main.bundle.js"
+      "https://cdn.jsdelivr.net/npm/h5p-standalone@v3.5.1/dist/main.bundle.js"
     )
       .done(function () {
         window.H5PStandalone = H5PStandalone;


### PR DESCRIPTION
The h5p-standalone added credentials mode to be 'include' that breaks when loading h5p content from an external storage (S3). So the current solution is to use an older version of the h5p-standalone version (v3.5.1).
fixes edly-io/h5pxblock#30
relates to tunapanda/h5p-standalone#151