### PR TITLE
add: completion event on content consumption

### DIFF
--- a/h5pxblock/static/js/src/h5pxblock.js
+++ b/h5pxblock/static/js/src/h5pxblock.js
@@ -58,7 +58,8 @@ function H5PPlayerXBlock(runtime, element, args) {
 
             let isCompleted =
               statement.verb.display["en-US"] === "answered" ||
-              statement.verb.display["en-US"] === "completed";
+              statement.verb.display["en-US"] === "completed" ||
+              statement.verb.display["en-US"] === "consumed";
             let isChild =
               statement.context &&
               statement.context.contextActivities &&


### PR DESCRIPTION
**Description** 
This PR adds a check on event of "consumed". 
These events are fired when content of "accordion" is used. 

**Reference Screenshot** 
![image](https://github.com/user-attachments/assets/92941879-1a85-48e3-a361-63ed3a7d81cf)

**Reasoning** 
- Accordion is listed at the top of example and downloads section of h5p site. 
- Accordion type content was not being marked as complete
- With this change it'll be marked as complete upon viewing it