### PR TITLE
Fixed path in resource_string to use package for compatibility with older versions

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -183,7 +183,10 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
-        data = importlib_resources.files(__name__).joinpath(path).read_bytes()
+        try:
+            data = importlib_resources.files(__name__).joinpath(path).read_bytes()
+        except TypeError:
+            data = importlib_resources.files(__package__).joinpath(path).read_bytes()
         return data.decode("utf8")
 
     def render_template(self, template_path, context):


### PR DESCRIPTION
The issue with using the `__name__` variable while reading files via the `importlib-resource` library in older versions (e.g., 3.1.2) results in the following error:

```
get_package raises TypeError('{!r} is not a package'.format(package))
TypeError: 'h5pxblock.h5pxblock' is not a package
```

This PR updates the reference to `__package__` instead of `__name__` to ensure compatibility with older versions of the library.

Changes have been tested on both versions 3.1.2 and 6.4.5 (latest) of `importlib-resources` and are working correctly.