### PR TITLE
fix: deleting cloud files only if the path exists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cypress-run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: cypress/browsers:latest
     steps:
       - name: Checkout

--- a/h5pxblock/utils.py
+++ b/h5pxblock/utils.py
@@ -63,17 +63,18 @@ def delete_existing_files_cloud(storage, path):
     """
     Recusively delete all files under given path on cloud storage
     """
-    log.info("%s path is being deleted on cloud", path)
-    dir_names, file_names = storage.listdir(path)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-        for file_name in file_names:
-            file_path = os.path.join(path, file_name)
-            future = executor.submit(storage.delete, file_path)
-            future.add_done_callback(future_result_handler)
+    if storage.exists(path):
+        log.info("%s path is being deleted on cloud", path)
+        dir_names, file_names = storage.listdir(path)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            for file_name in file_names:
+                file_path = os.path.join(path, file_name)
+                future = executor.submit(storage.delete, file_path)
+                future.add_done_callback(future_result_handler)
 
-    for dir_name in dir_names:
-        dir_path = os.path.join(path, dir_name)
-        delete_existing_files_cloud(storage, dir_path)
+        for dir_name in dir_names:
+            dir_path = os.path.join(path, dir_name)
+            delete_existing_files_cloud(storage, dir_path)
 
 
 def unpack_package_local_path(package, path):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def package_data(pkg, roots):
 
 setup(
     name='h5p-xblock',
-    version='0.2.15',
+    version='0.2.16',
     description='XBlock to play self hosted h5p content inside open edX',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- `storage.listdir(path)` throws an error for the path. As for the first time, path doesn't exist on S3. Error Occurred: `NoSuchKey: An error occurred (NoSuchKey) when calling the ListObjects operation: The specified key does not exist`.
- In this PR:
  - added a check if the specific path does exists or not before deleting the previously added content on that path, Skip deleting if it return False.
  - fix CI failure as CI is failing [here](https://github.com/edly-io/h5pxblock/actions/runs/13648230543/job/38151064603) and it's explanation can be found [here](https://github.com/actions/setup-python/issues/1053) along with it's fix.
  - bumped the version.