### PR TITLE
Fix: cloud storage path if custom domain is set

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -349,7 +349,10 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
                 unpack_and_upload_on_cloud(
                     h5p_package, H5P_STORAGE, self.cloud_storage_path
                 )
-                self.h5p_content_json_path = H5P_STORAGE.url(self.cloud_storage_path)
+                cloud_storage_path = (
+                    f"{H5P_STORAGE.bucket.name}/" if H5P_STORAGE.custom_domain else ""
+                ) + self.cloud_storage_path
+                self.h5p_content_json_path = H5P_STORAGE.url(cloud_storage_path)
         elif request.params["h5_content_path"]:
             self.h5p_content_json_path = request.params["h5_content_path"]
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def package_data(pkg, roots):
 
 setup(
     name='h5p-xblock',
-    version='0.2.16',
+    version='0.2.17',
     description='XBlock to play self hosted h5p content inside open edX',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- If `AWS_S3_CUSTOM_DOMAIN` setting is set instead if empty string, it doesn't create the correct cloud storage path. 
- In this PR:
  - made sure to add bucket name in the url if using custom domain to create correct URL.
  - version bump.