### PR TITLE
fix: naive and aware datetimes comparison

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -445,7 +445,7 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         """
         if not self.due:
             return False
-        return datetime.now() > self.due
+        return datetime.now(self.due.tzinfo) > self.due
 
     @staticmethod
     def workbench_scenarios():

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def package_data(pkg, roots):
 
 setup(
     name='h5p-xblock',
-    version='0.2.16',
+    version='0.2.17',
     description='XBlock to play self hosted h5p content inside open edX',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
In this PR:
- fixes `TypeError: can't compare offset-naive and offset-aware datetimes` error by making datetime.now(), aware datetime.
- bump version